### PR TITLE
Replace content type

### DIFF
--- a/lib/rspec_api_blueprint/spec_blueprint_translator.rb
+++ b/lib/rspec_api_blueprint/spec_blueprint_translator.rb
@@ -118,6 +118,7 @@ class SpecBlueprintTranslator
       current_env.each do |header, value|
         next unless allowed_headers.include?(header)
         header = header.gsub(/HTTP_/, '') if header == 'HTTP_AUTHORIZATION'
+        header = header.gsub(/CONTENT_TYPE/, 'CONTENT-TYPE') if header == 'CONTENT_TYPE'
         @handle.write "#{header}: #{value}\n".indent(12)
       end
       @handle.write "\n"

--- a/lib/rspec_api_blueprint/version.rb
+++ b/lib/rspec_api_blueprint/version.rb
@@ -1,3 +1,3 @@
 module RspecApiBlueprint
-  VERSION = '0.0.10'
+  VERSION = '0.0.11'
 end


### PR DESCRIPTION
The standard HTTP headers use Content-Type instead of CONTENT_TYPE, which is the header rails reports as being used. Overwrite that here.
